### PR TITLE
A: GitLab Duo in "What's new" sidebar

### DIFF
--- a/GenAI-Blocklist.txt
+++ b/GenAI-Blocklist.txt
@@ -636,6 +636,7 @@ about.gitlab.com##[data-ga-name="ai-assisted development"], [data-ga-name="ai fo
 ! * Blocks both the button to open Duo panel and the panel itself
 gitlab.com##.ai-panels
 ! Duo items in "What's new at GitLab" sidebar
+! * Accessed via "What's new" button in left sidebar
 gitlab.com##[data-testid="whats-new-article-toggle"]:has-text("GitLab Duo"):upward(1)
 
 ! ===========


### PR DESCRIPTION
The `featured-carousel` seems unused by now, but there are new `data-testid` elements we can use to block Duo-related announcements.

<img width="1036" height="768" alt="gitlab-duo-whats-new-sidebar" src="https://github.com/user-attachments/assets/04a88838-bf79-4554-96d0-020a26e7fe75" />
