### PR TITLE
GitLab: Remove "View summary" button in issues/epics

### DIFF
--- a/GenAI-Blocklist.txt
+++ b/GenAI-Blocklist.txt
@@ -737,6 +737,10 @@ gitlab.com##.ai-panels
 ! * Accessed via "What's new" button in left sidebar
 gitlab.com##[data-testid="whats-new-article-toggle"]:has-text("GitLab Duo"):upward(1)
 
+! -- https://gitlab.com/ (Group/Project issue pages - logged in)
+! "View summarize" button
+gitlab.com##.btn > svg[data-testid="tanuki-ai-icon"]:upward(1)
+
 ! ===========
 ! == Gmail ==
 ! ===========


### PR DESCRIPTION
<img width="828" height="190" alt="image" src="https://github.com/user-attachments/assets/88738015-39bc-444a-bf25-866787ad1ae2" />
