### PR TITLE
A: GitLab Duo as reviewer and commenter on MRs

### DIFF
--- a/GenAI-Blocklist.txt
+++ b/GenAI-Blocklist.txt
@@ -746,6 +746,8 @@ gitlab.com##.btn > svg[data-testid="tanuki-ai-icon"]:upward(1)
 gitlab.com##.reviewer-grid:has-text(GitLab Duo)
 gitlab.com##.note-header-info:has-text(GitLab Duo):upward(3)
 gitlab.com##.system-note-message:has-text(@GitLabDuo):upward(5)
+gitlab.com##.diff-grid-comments:has-text(GitLab Duo)
+gitlab.com##.tooltip-inner:has-text(GitLab Duo)
 ||gitlab.com/uploads/-/system/user/avatar/21826781/duo-bot.png
 
 ! ===========

--- a/GenAI-Blocklist.txt
+++ b/GenAI-Blocklist.txt
@@ -741,6 +741,13 @@ gitlab.com##[data-testid="whats-new-article-toggle"]:has-text("GitLab Duo"):upwa
 ! "View summarize" button
 gitlab.com##.btn > svg[data-testid="tanuki-ai-icon"]:upward(1)
 
+! -- https://gitlab.com/ (Project merge request pages)
+! GitLab Duo as reviewer and commenter on MRs
+gitlab.com##.reviewer-grid:has-text(GitLab Duo)
+gitlab.com##.note-header-info:has-text(GitLab Duo):upward(3)
+gitlab.com##.system-note-message:has-text(@GitLabDuo):upward(5)
+||gitlab.com/uploads/-/system/user/avatar/21826781/duo-bot.png
+
 ! ===========
 ! == Gmail ==
 ! ===========


### PR DESCRIPTION
These rules remove `@GitLabDuo` from MRs:

| reviewer sidebar | comments by that bot | also in the diff | and its activity notes |
|-|-|-|-|
| <img width="564" height="600" alt="image" src="https://github.com/user-attachments/assets/587970f7-b95a-44a1-a444-6b54e6206092" /> | <img width="740" height="214" alt="image" src="https://github.com/user-attachments/assets/f3a40a31-b626-4f3d-88a1-9aea73ad36c5" /> | <img width="273" height="155" alt="image" src="https://github.com/user-attachments/assets/0f3f67e7-8ae3-4714-9a0c-f1024d13569c" /> | <img width="1272" height="196" alt="image" src="https://github.com/user-attachments/assets/7f06ae03-4fc6-4448-a958-cc8c2014a266" /> |
