### PR TITLE
Update GenAI-Blocklist.txt to remove ScienceDirect reading assistant

### DIFF
--- a/GenAI-Blocklist.txt
+++ b/GenAI-Blocklist.txt
@@ -1882,6 +1882,8 @@ replug.io##.mantine-1fndqk8
 ! ===================
 ! "LeapSpace" floating promo
 www.sciencedirect.com###pendo-base
+! "Reading assistant" box
+www.sciencedirect.com###reading-assistant-container
 
 ! ===========
 ! == Scoot ==

--- a/GenAI-Blocklist.txt
+++ b/GenAI-Blocklist.txt
@@ -1882,6 +1882,7 @@ replug.io##.mantine-1fndqk8
 ! ===================
 ! "LeapSpace" floating promo
 www.sciencedirect.com###pendo-base
+! -- https://www.sciencedirect.com/science/article/pii/S0014579309010850
 ! "Reading assistant" box
 www.sciencedirect.com###reading-assistant-container
 


### PR DESCRIPTION
Remove ScienceDirect reading assistant.

Note: that's my first time contribution to and  ad block list, took inspiration from existing syntax, I hope it's alright.
