### PR TITLE
Add Google Docs Gemini popup to blocklist

### DIFF
--- a/GenAI-Blocklist.txt
+++ b/GenAI-Blocklist.txt
@@ -1004,6 +1004,9 @@ docs.google.com##.apps-menuitem:has([aria-label="Audio buttons f5"],[aria-label=
 docs.google.com##.apps-menuitem:has([aria-label="Audio f6"], [aria-label="Audio New f6"])
 ! "Tools" > "Gemini" in menubar
 docs.google.com##.apps-menuitem:has(.goog-menuitem-label[aria-label="Gemini 2"])
+! "Write with Gemini" footer popup
+docs.google.com##.WithHideTransition.kixWizBarkickWrapper
+docs.google.com##.appsElementsCalloutIsPrimary.appsElementsCalloutAnchorPaddingContainer
 
 ! ==================
 ! == Google Drive ==


### PR DESCRIPTION
This would block the following popup from appearing.
<img width="725" height="122" alt="image" src="https://github.com/user-attachments/assets/04403bf4-47e0-41b7-ae6e-3e6bfc8d8f3c" />
Thank you for your consideration on this PR.