### PR TITLE
A: Proquest Research Assistant AI panel

### DIFF
--- a/GenAI-Blocklist.txt
+++ b/GenAI-Blocklist.txt
@@ -2207,6 +2207,13 @@ docs.posit.co###kapa-widget-container
 ! "Ask AI" in navbar
 docs.posit.co##.nav-item:has(#custom-ask-ai-button)
 
+! ==============
+! == ProQuest ==
+! ==============
+! -- https://www.proquest.com/docview/3278796875/2B68B1B1A3E34B29PQ/10?accountid=14677&sourcetype=Scholarly%20Journals# (Requires login)
+! Research Assistant panel AI feature
+www.proquest.com###ra-panel-wrapper
+
 ! ======================
 ! == Quicken Simplifi ==
 ! ======================


### PR DESCRIPTION
<img width="1582" height="1495" alt="image" src="https://github.com/user-attachments/assets/e7c05246-8fd5-426b-b51f-d6a4a9413c01" />
https://www.proquest.com/docview/3278796875/2B68B1B1A3E34B29PQ/10?accountid=14677&sourcetype=Scholarly%20Journals#
You need to be logged in to access the article and see the AI panel.

Filtering ra-panel-wrapper seems to do the trick.