### PR TITLE
A: Google Docs: Floating selection "Refine" option

### DIFF
--- a/GenAI-Blocklist.txt
+++ b/GenAI-Blocklist.txt
@@ -1197,6 +1197,8 @@ docs.google.com##.apps-menuitem:has(.goog-menuitem-label[aria-label="Gemini 2"])
 ! "Write with Gemini" footer popup
 docs.google.com##.WithHideTransition.kixWizBarkickWrapper
 docs.google.com##.appsElementsCalloutIsPrimary.appsElementsCalloutAnchorPaddingContainer
+! "Refine" icon in text selection floating menu
+docs.google.com##.inlineFabBubbleContainerRefineButtonContainer
 
 ! ==================
 ! == Google Drive ==


### PR DESCRIPTION
Removes the "Refine" button out of the small floating menu when you select text. Thank you for your consideration.

Before:
<img width="399" height="71" alt="2026-05-29-185959_sway-screenshot" src="https://github.com/user-attachments/assets/e8e3b773-9416-4841-b1d8-9c5636a0450b" />

After:
<img width="369" height="65" alt="2026-05-29-190024_sway-screenshot" src="https://github.com/user-attachments/assets/dace935e-779d-41d3-a6a1-1bc4ca1f57ad" />
