### PR TITLE
M: humblebundle.com: Filter bundles that start with the word AI in it

### DIFF
--- a/GenAI-Blocklist.txt
+++ b/GenAI-Blocklist.txt
@@ -1734,7 +1734,7 @@ virtualagent.hpcloud.hp.com##.ac-actionSet > [aria-label="Get an AI Answer"]
 ! -- https://www.humblebundle.com/bundles
 ! Bundles involving AI
 ! * Exclude the "The Cybersecurity & AI Defense" bundle
-www.humblebundle.com##.bundle:is([href*="-ai-"], [href*="claude-code"], [href*="genai-"]):not([href*="cybersecurity"])
+www.humblebundle.com##.bundle:is([href*="-ai-"], [href*="claude-code"], [href*="genai-"], [href*="ai-"]):not([href*="cybersecurity"])
 
 ! ==========
 ! == IMDB ==

--- a/GenAI-Blocklist.txt
+++ b/GenAI-Blocklist.txt
@@ -1734,7 +1734,7 @@ virtualagent.hpcloud.hp.com##.ac-actionSet > [aria-label="Get an AI Answer"]
 ! -- https://www.humblebundle.com/bundles
 ! Bundles involving AI
 ! * Exclude the "The Cybersecurity & AI Defense" bundle
-www.humblebundle.com##.bundle:is([href*="-ai-"], [href*="claude-code"], [href*="genai-"], [href*="ai-"]):not([href*="cybersecurity"])
+www.humblebundle.com##.bundle:is([href*="/ai-"], [href*="-ai-"], [href*="claude-code"], [href*="genai-"]):not([href*="cybersecurity"])
 
 ! ==========
 ! == IMDB ==


### PR DESCRIPTION
Fixes bundles on humblebundle.com that have the word start with AI in it.

Before:
<img width="1920" height="1080" alt="Screenshot_20260712_180949" src="https://github.com/user-attachments/assets/0e10d011-307b-441f-aef9-4a5e7ee96790" />

After:
<img width="1920" height="1080" alt="Screenshot_20260712_181024" src="https://github.com/user-attachments/assets/c19e0e2f-7cc2-4fb3-864a-3911222f8e8f" />
