### PR TITLE
A: Copilot features on PR page

### DIFF
--- a/GenAI-Blocklist.txt
+++ b/GenAI-Blocklist.txt
@@ -1220,11 +1220,11 @@ github.com##.Footer-module__footerButtonWrapper__eCAAR
 ! -- https://github.com/Stevoisiak/Stevos-AI-Blocklist/pull/13 (Pull request)
 ! "Copilot" promo when adding reviewers via gear icon
 github.com##[partial-name="copilot-assisted-review-upsell"]
-! "Request review from Copilot"
+! "Request review from Copilot" (possibly enterprise only)
 github.com##.css-truncate:has([data-assignee-name="Copilot"])
-! Suggested Reviewer Dropdown: Copilot
+! Suggested Reviewer Dropdown: Copilot (possibly enterprise only)
 github.com###reviewers-select-menu label.select-menu-item:has(span.js-username:has-text("Copilot"))
-! Ask copilot button above comment box
+! Ask Copilot button above comment box (possibly enterprise only)
 github.com###copilot-md-menu-anchor-new_comment_field
 
 ! -- https://github.com/Stevoisiak/Stevos-AI-Blocklist/pull/13/changes (Viewing changed files of a pull request)

--- a/GenAI-Blocklist.txt
+++ b/GenAI-Blocklist.txt
@@ -1220,11 +1220,11 @@ github.com##.Footer-module__footerButtonWrapper__eCAAR
 ! -- https://github.com/Stevoisiak/Stevos-AI-Blocklist/pull/13 (Pull request)
 ! "Copilot" promo when adding reviewers via gear icon
 github.com##[partial-name="copilot-assisted-review-upsell"]
-! "Request review from Copilot" (possibly enterprise only)
+! "Request review from Copilot" (enterprise only)
 github.com##.css-truncate > div:has([data-assignee-name="Copilot"])
-! Suggested Reviewer Dropdown: Copilot (possibly enterprise only)
+! Suggested Reviewer Dropdown: Copilot (enterprise only)
 github.com##+js(json-edit-fetch-response, $.suggestions[?@.login=="Copilot"])
-! Ask Copilot button above comment box (possibly enterprise only)
+! Ask Copilot button above comment box (enterprise only)
 github.com###copilot-md-menu-anchor-new_comment_field
 
 ! -- https://github.com/Stevoisiak/Stevos-AI-Blocklist/pull/13/changes (Viewing changed files of a pull request)

--- a/GenAI-Blocklist.txt
+++ b/GenAI-Blocklist.txt
@@ -1220,6 +1220,12 @@ github.com##.Footer-module__footerButtonWrapper__eCAAR
 ! -- https://github.com/Stevoisiak/Stevos-AI-Blocklist/pull/13 (Pull request)
 ! "Copilot" promo when adding reviewers via gear icon
 github.com##[partial-name="copilot-assisted-review-upsell"]
+! "Request review from Copilot"
+github.com##.css-truncate:has([data-assignee-name="Copilot"])
+! Suggested Reviewer Dropdown: Copilot
+github.com###reviewers-select-menu label.select-menu-item:has(span.js-username:has-text("Copilot"))
+! Ask copilot button above comment box
+github.com###copilot-md-menu-anchor-new_comment_field
 
 ! -- https://github.com/Stevoisiak/Stevos-AI-Blocklist/pull/13/changes (Viewing changed files of a pull request)
 ! - Classic page

--- a/GenAI-Blocklist.txt
+++ b/GenAI-Blocklist.txt
@@ -1221,9 +1221,9 @@ github.com##.Footer-module__footerButtonWrapper__eCAAR
 ! "Copilot" promo when adding reviewers via gear icon
 github.com##[partial-name="copilot-assisted-review-upsell"]
 ! "Request review from Copilot" (possibly enterprise only)
-github.com##.css-truncate:has([data-assignee-name="Copilot"])
+github.com##.css-truncate > div:has([data-assignee-name="Copilot"])
 ! Suggested Reviewer Dropdown: Copilot (possibly enterprise only)
-github.com###reviewers-select-menu label.select-menu-item:has(span.js-username:has-text("Copilot"))
+github.com##+js(json-edit-fetch-response, $.suggestions[?@.login=="Copilot"])
 ! Ask Copilot button above comment box (possibly enterprise only)
 github.com###copilot-md-menu-anchor-new_comment_field
 


### PR DESCRIPTION
Removes three new copilot buttons found on the `/pull/##` page on GitHub.

<img width="555" height="187" alt="image" src="https://github.com/user-attachments/assets/cef62cd9-1378-4fdd-8572-81c9c43addc2" />

<img width="588" height="357" alt="image" src="https://github.com/user-attachments/assets/68248166-3669-40c5-95cd-852e6eb5d6c0" />

<img width="1393" height="379" alt="image" src="https://github.com/user-attachments/assets/a2dbd55d-b722-426f-a1de-0624fafdaa95" />

